### PR TITLE
add debug mode to enable verbose logging when needed

### DIFF
--- a/iris/config_service/run.py
+++ b/iris/config_service/run.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import os
 import tempfile
 import time
@@ -7,14 +6,16 @@ import time
 from iris.config_service.aws.ec2_tags import EC2Tags, MissingIrisTagsError
 from iris.config_service.aws.s3 import S3
 from iris.config_service.config_lint.linter import Linter
+from iris.utils.iris_logging import get_logger
 from iris.utils.prom_helpers import PromStrBuilder, PromFileWriter
-
-logger = logging.getLogger('iris.config_service')
 
 
 def run_config_service(aws_creds_path: str, s3_region_name: str, s3_bucket_env: str, s3_bucket_name: str,
                        s3_download_to_path: str, ec2_region_name: str, ec2_dev_instance_id: str, ec2_metadata_url: str,
-                       local_config_path: str, prom_dir_path: str, run_frequency: float, dev_mode: bool) -> None:
+                       local_config_path: str, prom_dir_path: str, run_frequency: float, log_path: str,
+                       log_debug_path: str, dev_mode: bool) -> None:
+    logger = get_logger('iris.config_service', log_path, log_debug_path)
+
     general_error_flag = False
     missing_iris_tags_error_flag = False
     while True:

--- a/iris/garbage_collector/run.py
+++ b/iris/garbage_collector/run.py
@@ -1,19 +1,19 @@
-import logging
 import os
 import time
 from typing import Tuple
 
 from iris.config_service.config_lint.linter import Linter
 from iris.garbage_collector.garbage_collector import GarbageCollector
+from iris.utils.iris_logging import get_logger
 from iris.utils.prom_helpers import PromStrBuilder, PromFileWriter
-
-logger = logging.getLogger('iris.garbage_collector')
 
 
 def run_garbage_collector(global_config_path: str, local_config_path: str, prom_dir_path: str, run_frequency: float,
-                          internal_metrics_whitelist: Tuple[str]) -> None:
-    general_error_flag = False
+                          internal_metrics_whitelist: Tuple[str], log_path: str, log_debug_path: str, ) -> None:
+    logger = get_logger('iris.garbage_collector', log_path, log_debug_path)
+
     prom_writer = PromFileWriter(logger=logger)
+    general_error_flag = False
     while True:
         try:
             logger.info('Resuming the Garbage_Collector')

--- a/iris/run.py
+++ b/iris/run.py
@@ -44,6 +44,12 @@ def run_iris(logger: logging.Logger, iris_config: ConfigParser) -> None:
         logger.info('Starting IRIS in {} mode\n'.format('DEV' if dev_mode else 'PROD'))
 
         # set path variables
+        log_debug_file_path = os.path.join(iris_root_path, 'iris.debug')
+        log_dir_path = os.path.join(iris_root_path, 'logs')
+        config_service_log_path = os.path.join(log_dir_path, 'config_service.log')
+        scheduler_log_path = os.path.join(log_dir_path, 'scheduler.log')
+        garbage_collector_log_path = os.path.join(log_dir_path, 'garbage_collector.log')
+
         aws_credentials_path = os.path.join(iris_root_path, 'aws_credentials')
         s3_download_to_path = os.path.join(iris_root_path, 'downloads')
         local_config_file_path = os.path.join(iris_root_path, 'local_config.json')
@@ -96,6 +102,8 @@ def run_iris(logger: logging.Logger, iris_config: ConfigParser) -> None:
             'local_config_path': local_config_file_path,
             'prom_dir_path': prom_dir_path,
             'run_frequency': config_service_settings.getfloat('run_frequency'),
+            'log_path': config_service_log_path,
+            'log_debug_path': log_debug_file_path,
             'dev_mode': dev_mode
         }
         config_service_process = multiprocessing.Process(
@@ -116,6 +124,8 @@ def run_iris(logger: logging.Logger, iris_config: ConfigParser) -> None:
             'prom_dir_path': prom_dir_path,
             'run_frequency': scheduler_settings.getfloat('run_frequency'),
             'internal_metrics_whitelist': internal_metrics_whitelist,
+            'log_path': scheduler_log_path,
+            'log_debug_path': log_debug_file_path,
         }
         scheduler_process = multiprocessing.Process(
             target=run_scheduler,
@@ -135,6 +145,8 @@ def run_iris(logger: logging.Logger, iris_config: ConfigParser) -> None:
             'prom_dir_path': prom_dir_path,
             'run_frequency': scheduler_settings.getfloat('run_frequency'),
             'internal_metrics_whitelist': internal_metrics_whitelist,
+            'log_path': garbage_collector_log_path,
+            'log_debug_path': log_debug_file_path,
         }
         garbage_collector_process = multiprocessing.Process(
             target=run_garbage_collector,

--- a/iris/scheduler/run.py
+++ b/iris/scheduler/run.py
@@ -1,22 +1,20 @@
-import logging
 import os
 import time
 from typing import Tuple
 
 from iris.config_service.config_lint.linter import Linter
 from iris.scheduler.scheduler import Scheduler
+from iris.utils.iris_logging import get_logger
 from iris.utils.prom_helpers import PromStrBuilder, PromFileWriter
-
-logger = logging.getLogger('iris.scheduler')
 
 
 def run_scheduler(global_config_path: str, local_config_path: str, prom_dir_path: str, run_frequency: float,
-                  internal_metrics_whitelist: Tuple[str]) -> None:
+                  internal_metrics_whitelist: Tuple[str], log_path: str, log_debug_path: str, ) -> None:
+    logger = get_logger('iris.scheduler', log_path, log_debug_path)
+
     error_flag = 0
     while True:
         try:
-            logger.info('Resuming the Scheduler')
-
             sleep_total = 0  # the accumulated sleep time for checking the global_config and local_config
             sleep_increment = 10  # check for global_config and local_config every 5 seconds if they don't exist
             max_wait_time = 120  # max wait/sleep time that the scheduler will wait for these configs

--- a/iris/utils/iris_logging.py
+++ b/iris/utils/iris_logging.py
@@ -1,0 +1,22 @@
+import logging
+import os
+
+
+def get_logger(name: str, log_file_path: str, log_debug_file_path: str) -> logging.Logger:
+    logger = logging.getLogger(name)
+
+    if os.path.isfile(log_debug_file_path):
+        logger.setLevel(logging.DEBUG)
+    else:
+        logger.setLevel(logging.WARNING)
+
+    format = logging.Formatter(
+        fmt='%(asctime)s %(name)-12s %(levelname)s %(process)-8d %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S'
+    )
+
+    iris_service_file_handler = logging.FileHandler(log_file_path)
+    iris_service_file_handler.setFormatter(format)
+    logger.addHandler(iris_service_file_handler)
+
+    return logger

--- a/iris/utils/main_helpers.py
+++ b/iris/utils/main_helpers.py
@@ -1,38 +1,5 @@
 import logging
-import os
 from configparser import ConfigParser
-
-
-def setup_iris_logging(iris_root_path: str) -> logging.Logger:
-    logger = logging.getLogger('iris')
-    logger.setLevel(logging.DEBUG)
-
-    iris_log_path = os.path.join(iris_root_path, 'logs')
-    os.makedirs(iris_log_path, exist_ok=True)
-
-    format = logging.Formatter(
-        fmt='%(asctime)s %(name)-12s %(levelname)s %(process)-8d %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S'
-    )
-
-    config_service_file_handler = logging.FileHandler(os.path.join(iris_log_path, 'config_service.log'))
-    config_service_file_handler.setFormatter(format)
-    logging.getLogger('iris.config_service').addHandler(config_service_file_handler)
-
-    scheduler_file_handler = logging.FileHandler(os.path.join(iris_log_path, 'scheduler.log'))
-    scheduler_file_handler.setFormatter(format)
-    logging.getLogger('iris.scheduler').addHandler(scheduler_file_handler)
-
-    garbage_collector_file_handler = logging.FileHandler(os.path.join(iris_log_path, 'garbage_collector.log'))
-    garbage_collector_file_handler.setFormatter(format)
-    logging.getLogger('iris.garbage_collector').addHandler(garbage_collector_file_handler)
-
-    iris_main_file_handler = logging.FileHandler(os.path.join(iris_log_path, 'iris_main.log'))
-    iris_main_file_handler.setFormatter(format)
-    iris_main_logger = logging.getLogger('iris.main')
-    iris_main_logger.addHandler(iris_main_file_handler)
-
-    return iris_main_logger
 
 
 def check_iris_dev_settings(iris_config: ConfigParser, logger: logging.Logger) -> None:

--- a/iris/utils/util.py
+++ b/iris/utils/util.py
@@ -22,7 +22,10 @@ def read_config_file(config_path: str, logger: Logger = None) -> ConfigParser:
 def check_file_exists(file_path: str, file_type: str, logger: Logger) -> bool:
     if not os.path.isfile(file_path):
         err_msg = 'The {} file path {} does not exist or is incorrect. Check the path'.format(file_type, file_path)
-        logger.error(err_msg)
+        if file_type == 'aws_credentials':
+            logger.error(err_msg)
+        else:
+            logger.warning(err_msg)
         raise OSError(err_msg)
 
     return True

--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ from configparser import ConfigParser
 import daemon
 
 from iris.run import run_iris
-from iris.utils import main_helpers
+from iris.utils.iris_logging import get_logger
+from iris.utils.main_helpers import check_iris_dev_settings
 from iris.utils.util import read_config_file
 
 CONFIG_NAME = 'iris.cfg'
@@ -14,9 +15,14 @@ CONFIG_NAME = 'iris.cfg'
 def main(iris_config: ConfigParser) -> None:
     iris_root_path = iris_config['main_settings']['iris_root_path']
 
-    iris_main_logger = main_helpers.setup_iris_logging(iris_root_path=iris_root_path)
+    log_directory_path = os.path.join(iris_root_path, 'logs')
+    os.makedirs(log_directory_path, exist_ok=True)
 
-    main_helpers.check_iris_dev_settings(iris_config, iris_main_logger)
+    iris_main_log_path = os.path.join(log_directory_path, 'iris_main.log')
+    log_debug_file_path = os.path.join(iris_root_path, 'iris.debug')
+    iris_main_logger = get_logger('iris.main', iris_main_log_path, log_debug_file_path)
+
+    check_iris_dev_settings(iris_config, iris_main_logger)
 
     run_iris(logger=iris_main_logger, iris_config=iris_config)
 


### PR DESCRIPTION
we need the ability to increase verbosity for additional debug output in the logs when needed, but normally have low verbosity and only log error-type output.

The ideal solution would be adding a '-v' verbosity switch to the executable. However it appears this is not possible when using pyinstaller. We don't want to have to create specialized 'debug' builds. If we have a host where Iris is running which encounters an odd unexpected error, we should be able to restart the Iris service in 'debug' mode which will increase the log verbosity.

Since we cannot use a switch, a simple alternative is to have iris look for a file called iris.debug in /opt/iris. If this files exists, Iris runs in debug mode. This makes it easy to temporarily increase verbosity - create a debug file and restart Iris.
